### PR TITLE
Remove ext-intl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4|^8.0",
-        "ext-intl": "*",
         "psr/event-dispatcher": "1.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

Ext-intl is no longer required in this package