### PR TITLE
Use `SimpleMessageFormatter` to format messages when missing translation category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.2 under development
 
-- no changes in this release.
+- Enh #72: Use `SimpleMessageFormatter` to format messages when missing translation category (@vjik)
 
 ## 1.1.1 September 09, 2022
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -25,6 +25,8 @@ final class Translator implements TranslatorInterface
      */
     private array $categorySources = [];
 
+    private ?SimpleMessageFormatter $simpleMessageFormatter = null;
+
     /**
      * @param string $locale Default locale to use if locale is not specified explicitly.
      * @param string|null $fallbackLocale Locale to use if message for the locale specified was not found. Null for none.
@@ -80,7 +82,7 @@ final class Translator implements TranslatorInterface
             if ($this->eventDispatcher !== null) {
                 $this->eventDispatcher->dispatch(new MissingTranslationCategoryEvent($category));
             }
-            return $id;
+            return $this->getSimpleMessageFormatter()->format($id, $parameters);
         }
 
         return $this->translateUsingCategorySources($id, $parameters, $category, $locale);
@@ -142,5 +144,13 @@ final class Translator implements TranslatorInterface
 
         $categorySource = end($this->categorySources[$category]);
         return $categorySource->format($id, $parameters, $locale);
+    }
+
+    private function getSimpleMessageFormatter(): SimpleMessageFormatter
+    {
+        if ($this->simpleMessageFormatter === null) {
+            $this->simpleMessageFormatter = new SimpleMessageFormatter();
+        }
+        return $this->simpleMessageFormatter;
     }
 }

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -111,8 +111,12 @@ final class TranslatorTest extends TestCase
     {
         $locale = 'en';
         $translator = new Translator($locale);
-        $this->assertEquals('Without translation', $translator->translate('Without translation'));
-        $this->assertEquals('Without translation', $translator->translate('Without translation', [], ''));
+        $this->assertSame('Without translation', $translator->translate('Without translation'));
+        $this->assertSame('Without translation', $translator->translate('Without translation', [], ''));
+        $this->assertSame(
+            'Without 1 translation',
+            $translator->translate('Without {param} translation', ['param' => 1])
+        );
     }
 
     public function testWithoutDefaultCategoryMissingEvent(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #72
