### PR TITLE
Set `en_US` as default locale for translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.2 under development
 
-- no changes in this release.
+- Enh #73: Set `en_US` as default locale for translator (@vjik)
 
 ## 1.1.1 September 09, 2022
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -31,7 +31,7 @@ final class Translator implements TranslatorInterface
      * @param EventDispatcherInterface|null $eventDispatcher Event dispatcher for translation events. Null for none.
      */
     public function __construct(
-        string $locale,
+        string $locale = 'en_US',
         ?string $fallbackLocale = null,
         ?EventDispatcherInterface $eventDispatcher = null
     ) {

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -16,6 +16,12 @@ use Yiisoft\Translator\TranslatorInterface;
 
 final class TranslatorTest extends TestCase
 {
+    public function testDefaultLocale(): void
+    {
+        $translator = new Translator();
+        $this->assertSame('en_US', $translator->getLocale());
+    }
+
     private function getMessages(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -
