### PR TITLE
Add default message formatter in translator and add `NullMessageFormatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Enh #74: Dispatch `MissingTranslationCategoryEvent` once per category (@vjik)
 - Enh #73: Set `en_US` as default locale for translator (@vjik)
-- Enh #72: Use `SimpleMessageFormatter` to format messages when missing translation category (@vjik)
+- Enh #72, #75: Format messages when missing translation category (@vjik)
+- New #75: Add `NullMessageFormatter` that returns message as is (@vjik)
 - Enh #69: Raise minimum PHP version to 8.0 (@xepozz, @vjik)
 
 ## 1.1.1 September 09, 2022

--- a/src/NullMessageFormatter.php
+++ b/src/NullMessageFormatter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Translator;
+
+final class NullMessageFormatter implements MessageFormatterInterface
+{
+    public function format(string $message, array $parameters, string $locale): string
+    {
+        return $message;
+    }
+}

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -15,6 +15,8 @@ use Yiisoft\Translator\Event\MissingTranslationEvent;
  */
 final class Translator implements TranslatorInterface
 {
+    private MessageFormatterInterface $defaultMessageFormatter;
+
     private string $defaultCategory = 'app';
 
     /**
@@ -36,8 +38,9 @@ final class Translator implements TranslatorInterface
         private string $locale = 'en_US',
         private ?string $fallbackLocale = null,
         private ?EventDispatcherInterface $eventDispatcher = null,
-        private MessageFormatterInterface $defaultMessageFormatter = new NullMessageFormatter()
+        ?MessageFormatterInterface $defaultMessageFormatter = null,
     ) {
+        $this->defaultMessageFormatter = $defaultMessageFormatter ?? new NullMessageFormatter();
     }
 
     public function addCategorySource(CategorySource $category): void

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -22,8 +22,6 @@ final class Translator implements TranslatorInterface
      */
     private array $categorySources = [];
 
-    private ?SimpleMessageFormatter $simpleMessageFormatter = null;
-
     /**
      * @psalm-var array<string,true>
      */
@@ -37,7 +35,8 @@ final class Translator implements TranslatorInterface
     public function __construct(
         private string $locale = 'en_US',
         private ?string $fallbackLocale = null,
-        private ?EventDispatcherInterface $eventDispatcher = null
+        private ?EventDispatcherInterface $eventDispatcher = null,
+        private MessageFormatterInterface $defaultMessageFormatter = new NullMessageFormatter()
     ) {
     }
 
@@ -79,7 +78,7 @@ final class Translator implements TranslatorInterface
 
         if (empty($this->categorySources[$category])) {
             $this->dispatchMissingTranslationCategoryEvent($category);
-            return $this->getSimpleMessageFormatter()->format($id, $parameters);
+            return $this->defaultMessageFormatter->format($id, $parameters, $locale);
         }
 
         return $this->translateUsingCategorySources($id, $parameters, $category, $locale);
@@ -152,13 +151,5 @@ final class Translator implements TranslatorInterface
             $this->dispatchedMissingTranslationCategoryEvents[$category] = true;
             $this->eventDispatcher->dispatch(new MissingTranslationCategoryEvent($category));
         }
-    }
-
-    private function getSimpleMessageFormatter(): SimpleMessageFormatter
-    {
-        if ($this->simpleMessageFormatter === null) {
-            $this->simpleMessageFormatter = new SimpleMessageFormatter();
-        }
-        return $this->simpleMessageFormatter;
     }
 }

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -11,6 +11,7 @@ use Yiisoft\Translator\Event\MissingTranslationCategoryEvent;
 use Yiisoft\Translator\Event\MissingTranslationEvent;
 use Yiisoft\Translator\MessageFormatterInterface;
 use Yiisoft\Translator\MessageReaderInterface;
+use Yiisoft\Translator\SimpleMessageFormatter;
 use Yiisoft\Translator\Translator;
 use Yiisoft\Translator\TranslatorInterface;
 
@@ -115,14 +116,10 @@ final class TranslatorTest extends TestCase
 
     public function testWithoutDefaultCategory(): void
     {
-        $locale = 'en';
-        $translator = new Translator($locale);
+        $translator = new Translator();
         $this->assertSame('Without translation', $translator->translate('Without translation'));
         $this->assertSame('Without translation', $translator->translate('Without translation', [], ''));
-        $this->assertSame(
-            'Without 1 translation',
-            $translator->translate('Without {param} translation', ['param' => 1])
-        );
+        $this->assertSame('Hello, {name}!', $translator->translate('Hello, {name}!', ['name' => 'kitty']));
     }
 
     public function testWithoutDefaultCategoryMissingEvent(): void
@@ -139,6 +136,14 @@ final class TranslatorTest extends TestCase
         $translator = new Translator($locale, null, $eventDispatcher);
         $this->assertEquals('Without translation', $translator->translate('Without translation'));
         $this->assertEquals('Without translation 2', $translator->translate('Without translation 2'));
+    }
+
+    public function testWithoutDefaultCategoryWithCustomDefaultMessageFormatter(): void
+    {
+        $translator = new Translator(
+            defaultMessageFormatter: new SimpleMessageFormatter(),
+        );
+        $this->assertSame('Hello, kitty!', $translator->translate('Hello, {name}!', ['name' => 'kitty']));
     }
 
     public function testMultiCategories(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -
