### PR TITLE
Add parameter `$defaultCategory` to `Translator` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - Enh #76: Make message formatter in category source optional (@vjik)
 - New #78: Add `IntlMessageFormatter` that utilizes PHP intl extension message formatting capabilities (@vjik)
 - Chg #81: Make category parameter in `TranslatorInterface::addCategorySources()` variadic, and remove 
- `TranslatorInterface::addCategorySource()` method (@vjik) 
+ `TranslatorInterface::addCategorySource()` method (@vjik)
+- New #82: Add parameter `$defaultCategory` to `Translator` constructor (@vjik)
 
 ## 1.1.1 September 09, 2022
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -18,8 +18,6 @@ final class Translator implements TranslatorInterface
 {
     private MessageFormatterInterface $defaultMessageFormatter;
 
-    private string $defaultCategory = 'app';
-
     /**
      * @var array Array of category message sources indexed by category names.
      * @psalm-var array<string,CategorySource[]>
@@ -39,6 +37,7 @@ final class Translator implements TranslatorInterface
     public function __construct(
         private string $locale = 'en_US',
         private ?string $fallbackLocale = null,
+        private string $defaultCategory = 'app',
         private ?EventDispatcherInterface $eventDispatcher = null,
         ?MessageFormatterInterface $defaultMessageFormatter = null,
     ) {

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -105,9 +105,8 @@ final class TranslatorTest extends TestCase
         string $expected
     ): void {
         $translator = new Translator(
-            $locale,
-            null,
-            $this->createMock(EventDispatcherInterface::class)
+            locale: $locale,
+            eventDispatcher: $this->createMock(EventDispatcherInterface::class)
         );
         $categorySource = $this->createCategory($categoryName, $this->getMessages());
         $translator->addCategorySources($categorySource);
@@ -133,7 +132,10 @@ final class TranslatorTest extends TestCase
             ->with(new MissingTranslationCategoryEvent('app'));
 
         $locale = 'en';
-        $translator = new Translator($locale, null, $eventDispatcher);
+        $translator = new Translator(
+            locale: $locale,
+            eventDispatcher: $eventDispatcher
+        );
         $this->assertEquals('Without translation', $translator->translate('Without translation'));
         $this->assertEquals('Without translation 2', $translator->translate('Without translation 2'));
     }
@@ -447,9 +449,9 @@ final class TranslatorTest extends TestCase
         string $expected
     ): void {
         $translator = new Translator(
-            $locale,
-            $fallbackLocale,
-            $this->createMock(EventDispatcherInterface::class)
+            locale: $locale,
+            fallbackLocale: $fallbackLocale,
+            eventDispatcher: $this->createMock(EventDispatcherInterface::class)
         );
         $translator->addCategorySources($this->createCategory($categoryName, $this->getMessages()));
 
@@ -481,9 +483,8 @@ final class TranslatorTest extends TestCase
         /** @var EventDispatcherInterface $eventDispatcher */
 
         $translator = new Translator(
-            $locale,
-            null,
-            $eventDispatcher
+            locale: $locale,
+            eventDispatcher: $eventDispatcher
         );
         $translator->addCategorySources($this->createCategory($categoryName, $this->getMessages()));
 
@@ -502,9 +503,8 @@ final class TranslatorTest extends TestCase
         string $expected
     ): void {
         $translator = new Translator(
-            $defaultLocale,
-            null,
-            $this->createMock(EventDispatcherInterface::class)
+            locale: $defaultLocale,
+            eventDispatcher: $this->createMock(EventDispatcherInterface::class)
         );
         $translator->addCategorySources($this->createCategory($categoryName, $this->getMessages()));
         $this->assertEquals($defaultLocale, $translator->getLocale());
@@ -529,9 +529,8 @@ final class TranslatorTest extends TestCase
 
         /** @var EventDispatcherInterface $eventDispatcher */
         $translator = new Translator(
-            'en-US',
-            null,
-            $eventDispatcher
+            locale: 'en-US',
+            eventDispatcher: $eventDispatcher
         );
         $translator->addCategorySources($this->createCategory('app', $this->getMessages()));
 
@@ -550,9 +549,8 @@ final class TranslatorTest extends TestCase
 
         /** @var EventDispatcherInterface $eventDispatcher */
         $translator = new Translator(
-            'en',
-            null,
-            $eventDispatcher
+            locale: 'en',
+            eventDispatcher: $eventDispatcher
         );
         $translator->addCategorySources($this->createCategory('app', $this->getMessages()));
 

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -322,6 +322,32 @@ final class TranslatorTest extends TestCase
         $this->assertEquals($expected, $translator->translate($id, $params, $category, $locale));
     }
 
+    public function testCustomDefaultCategory(): void
+    {
+        $translator = new Translator(
+            locale: 'en',
+            defaultCategory: 'app2',
+        );
+        $translator->addCategorySources(
+            $this->createCategory('app', [
+                'app' => [
+                    'en' => [
+                        'test.id1' => 'app: Test 1 on the (en)',
+                    ],
+                ],
+            ]),
+            $this->createCategory('app2', [
+                'app2' => [
+                    'en' => [
+                        'test.id1' => 'app2: Test 1 on the (en)',
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertSame('app2: Test 1 on the (en)', $translator->translate('test.id1'));
+    }
+
     public function testWithCategory(): void
     {
         $locale = 'en';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #77 (partly)
