### PR TITLE
In `TranslatorInterface` rename method `withCategory()` to `withDefaultCategory()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Chg #81: Make category parameter in `TranslatorInterface::addCategorySources()` variadic, and remove 
  `TranslatorInterface::addCategorySource()` method (@vjik)
 - New #82: Add parameter `$defaultCategory` to `Translator` constructor (@vjik)
+- Chg #84: In `TranslatorInterface` rename method `withCategory()` to `withDefaultCategory()` (@vjik)
 
 ## 1.1.1 September 09, 2022
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ echo $translator->withLocale($newDefaultLocale);
 
 ```php
 $newDefaultCategoryId = 'module2';
-echo $translator->withCategory($newDefaultCategoryId);
+echo $translator->withDefaultCategory($newDefaultCategoryId);
 ```
 
 ## Additional info

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -86,7 +86,7 @@ final class Translator implements TranslatorInterface
     /**
      * @psalm-immutable
      */
-    public function withCategory(string $category): self
+    public function withDefaultCategory(string $category): self
     {
         if (!isset($this->categorySources[$category])) {
             throw new RuntimeException('Category with name "' . $category . '" does not exist.');

--- a/src/TranslatorInterface.php
+++ b/src/TranslatorInterface.php
@@ -51,7 +51,7 @@ interface TranslatorInterface
      *
      * @psalm-immutable
      */
-    public function withCategory(string $category): self;
+    public function withDefaultCategory(string $category): self;
 
     /**
      * Get a new Translator instance with locale to be used by default in case locale isn't specified explicitly.

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -348,7 +348,7 @@ final class TranslatorTest extends TestCase
         $this->assertSame('app2: Test 1 on the (en)', $translator->translate('test.id1'));
     }
 
-    public function testWithCategory(): void
+    public function testWithDefaultCategory(): void
     {
         $locale = 'en';
         $translator = new Translator($locale);
@@ -368,7 +368,7 @@ final class TranslatorTest extends TestCase
         ]));
         $this->assertEquals('app: Test 1 on the (en)', $translator->translate('test.id1'));
 
-        $newTranslator = $translator->withCategory('app2');
+        $newTranslator = $translator->withDefaultCategory('app2');
         $this->assertNotSame($translator, $newTranslator);
         $this->assertEquals('app: Test 1 on the (en)', $translator->translate('test.id1'));
         $this->assertEquals('app2: Test 1 on the (en)', $newTranslator->translate('test.id1'));
@@ -423,7 +423,7 @@ final class TranslatorTest extends TestCase
         $this->assertEquals('app3: Test 1 on the (en)', $translator->translate('test.id1', [], 'app3'));
     }
 
-    public function testWithNotExistCategory(): void
+    public function testWithNotExistDefaultCategory(): void
     {
         $locale = 'en';
         $translator = new Translator($locale);
@@ -445,7 +445,7 @@ final class TranslatorTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Category with name "app3" does not exist.');
 
-        $translator->withCategory('app3');
+        $translator->withDefaultCategory('app3');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #77 
