### PR TITLE
Add `IdMessageReader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.1 under development
 
-- no changes in this release.
+- New #91: Add `IdMessageReader` that returns ID as message and don't support receiving all messages (@vjik)
 
 ## 2.0.0 November 08, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.1 under development
 
-- New #91: Add `IdMessageReader` that returns ID as message and don't support receiving all messages (@vjik)
+- New #91: Add `IdMessageReader` that returns ID as message and doesn't support getting all messages at once (@vjik)
 
 ## 2.0.0 November 08, 2022
 

--- a/src/IdMessageReader.php
+++ b/src/IdMessageReader.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Translator;
+
+use RuntimeException;
+
+/**
+ * ID message reader returns ID as message and don't support receiving all messages.
+ */
+final class IdMessageReader implements MessageReaderInterface
+{
+    public function getMessage(string $id, string $category, string $locale, array $parameters = []): string
+    {
+        return $id;
+    }
+
+    public function getMessages(string $category, string $locale): array
+    {
+        throw new RuntimeException('IdMessageReader do not support receiving all messages.');
+    }
+}

--- a/src/IdMessageReader.php
+++ b/src/IdMessageReader.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Translator;
 use RuntimeException;
 
 /**
- * ID message reader returns ID as message and don't support receiving all messages.
+ * ID message reader returns ID as message and doesn't support getting all messages at once.
  */
 final class IdMessageReader implements MessageReaderInterface
 {
@@ -18,6 +18,6 @@ final class IdMessageReader implements MessageReaderInterface
 
     public function getMessages(string $category, string $locale): array
     {
-        throw new RuntimeException('IdMessageReader do not support receiving all messages.');
+        throw new RuntimeException('IdMessageReader doesn\'t support getting all messages at once.');
     }
 }

--- a/tests/IdMessageReaderTest.php
+++ b/tests/IdMessageReaderTest.php
@@ -22,7 +22,7 @@ final class IdMessageReaderTest extends TestCase
         $reader = new IdMessageReader();
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('IdMessageReader do not support receiving all messages.');
+        $this->expectExceptionMessage('IdMessageReader doesn\'t support getting all messages at once');
         $reader->getMessages('my-module', 'en_US');
     }
 }

--- a/tests/IdMessageReaderTest.php
+++ b/tests/IdMessageReaderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Translator\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Yiisoft\Translator\IdMessageReader;
+
+final class IdMessageReaderTest extends TestCase
+{
+    public function testGetMessage(): void
+    {
+        $reader = new IdMessageReader();
+
+        $this->assertSame('test', $reader->getMessage('test', 'my-module', 'en_US'));
+    }
+
+    public function testGetMessages(): void
+    {
+        $reader = new IdMessageReader();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('IdMessageReader do not support receiving all messages.');
+        $reader->getMessages('my-module', 'en_US');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

ID message reader returns ID as message and don't support receiving all messages.
