### PR TITLE
Throw exceptions on empty and not passed parameters, cast `null` to empty string in `SimpleMessageFormatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.1.1 under development
 
-- no changes in this release.
+- Bug #93: Throw exceptions on empty and not passed parameters, cast `null` to empty string in `SimpleMessageFormatter` 
+  (@arogachev)
 
 ## 2.1.0 November 15, 2022
 

--- a/src/SimpleMessageFormatter.php
+++ b/src/SimpleMessageFormatter.php
@@ -23,13 +23,17 @@ class SimpleMessageFormatter implements MessageFormatterInterface
 
         foreach ($matches[0] as $match) {
             $parts = explode(',', $match);
-            $parameter = trim($parts[0], '{}');
+            $parameter = trim($parts[0], '{} ');
 
-            if (!isset($parameters[$parameter])) {
+            if ($parameter === '') {
+                throw new InvalidArgumentException('Parameter\'s name can not be empty.');
+            }
+
+            if (!array_key_exists($parameter, $parameters)) {
                 throw new InvalidArgumentException("\"$parameter\" parameter's value is missing.");
             }
 
-            $value = $parameters[$parameter];
+            $value = $parameters[$parameter] ?? '';
 
             if (!is_scalar($value)) {
                 continue;

--- a/tests/SimpleMessageFormatterTest.php
+++ b/tests/SimpleMessageFormatterTest.php
@@ -13,7 +13,6 @@ class SimpleMessageFormatterTest extends TestCase
     public function formatProvider(): array
     {
         return [
-            // simple
             'simple, scalar (integer)' => [
                 'Test number: {number}',
                 ['number' => 5],
@@ -29,7 +28,6 @@ class SimpleMessageFormatterTest extends TestCase
                 ['arr' => ['string data']],
                 'Test array: {arr}',
             ],
-            // plural
             'plural, one' => [
                 '{min, plural, one{character} other{characters}}',
                 ['min' => 1],
@@ -50,18 +48,21 @@ class SimpleMessageFormatterTest extends TestCase
                 ['min' => 1],
                 'character',
             ],
-            // not supported
             'not supported' => [
                 '{min, notsupported}',
                 ['min' => 1],
                 '1',
             ],
-            // complex
             'complex' => [
                 'text1 {param1} text2 {param2, number} text3 {param3, plural, one{item} other{items}} text4 {param4} ' .
                 'text5',
                 ['param1' => 1, 'param2' => 2, 'param3' => 3, 'param4' => 4],
                 'text1 1 text2 2 text3 items text4 4 text5',
+            ],
+            'parameter with null value' => [
+                'Attribute - {attribute}, type - {type}.',
+                ['attribute' => null, 'type' => 'int'],
+                'Attribute - , type - int.',
             ],
         ];
     }
@@ -130,5 +131,27 @@ class SimpleMessageFormatterTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('"min" parameter\'s value is missing.');
         $formatter->format('{min}', []);
+    }
+
+    public function dataFormatWithEmptyParameters(): array
+    {
+        return [
+            'empty without parameters' => ['{}', []],
+            'empty with parameters' => ['{}', ['' => 'test']],
+            'empty after trimming without parameters' => ['{ }', []],
+            'empty after trimming with parameters' => ['{ }', [' ' => 'test']],
+        ];
+    }
+
+    /**
+     * @dataProvider dataFormatWithEmptyParameters
+     */
+    public function testFormatWithEmptyParameters(string $message, array $parameters): void
+    {
+        $formatter = new SimpleMessageFormatter();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Parameter\'s name can not be empty.');
+        $formatter->format($message, $parameters);
     }
 }

--- a/tests/envs/WithIntl/IntlMessageFormatterTest.php
+++ b/tests/envs/WithIntl/IntlMessageFormatterTest.php
@@ -15,7 +15,7 @@ final class IntlMessageFormatterTest extends TestCase
     private const F_VALUE = 2e+8;
     private const F_VALUE_FORMATTED = '200,000,000';
     private const D = 'd';
-    private const D_VALUE = 200000000.101;
+    private const D_VALUE = 200_000_000.101;
     private const D_VALUE_FORMATTED = '200,000,000.101';
     private const D_VALUE_FORMATTED_INTEGER = '200,000,000';
     private const SUBJECT = 'сабж';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 
