### PR TITLE
Add `getMessages` method to `CategorySource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Yii Message Translator Change Log
 
+## 2.1.1 under development
+
+- no changes in this release.
+
 ## 2.1.0 November 15, 2022
 
 - New #91: Add `IdMessageReader` that returns ID as message and doesn't support getting all messages at once (@vjik)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.1 under development
 
-- New #94: Add `getMessages` method to `CategorySource` (@xepozz)
+- New #94: Add `getMessages()` method to `CategorySource` (@xepozz)
 
 ## 2.1.0 November 15, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.1 under development
 
-- no changes in this release.
+- New #94: Add `getMessages` method to `CategorySource` (@xepozz)
 
 ## 2.1.0 November 15, 2022
 

--- a/src/CategorySource.php
+++ b/src/CategorySource.php
@@ -52,6 +52,33 @@ final class CategorySource
     }
 
     /**
+     * @param string $locale Locale of messages to get.
+     *
+     * @psalm-return array<string, array<string, string>>
+     *
+     * @return array All messages from category. The format is the following:
+     *
+     * ```php
+     * [
+     *   'key1' => [
+     *     'message' => 'translation1',
+     *     // Extra metadata that writer may use:
+     *     'comment' => 'Translate carefully!',
+     *   ],
+     *   'key2' => [
+     *     'message' => 'translation2',
+     *     // Extra metadata that writer may use:
+     *     'comment' => 'Translate carefully!',
+     *   ],
+     * ]
+     * ```
+     */
+    public function getMessages(string $locale): array
+    {
+        return $this->reader->getMessages($this->name, $locale);
+    }
+
+    /**
      * Format the message given parameters and locale.
      *
      * @param string $message Message to be formatted.

--- a/src/CategorySource.php
+++ b/src/CategorySource.php
@@ -72,6 +72,8 @@ final class CategorySource
      *   ],
      * ]
      * ```
+     *
+     * @see MessageReaderInterface::getMessages()
      */
     public function getMessages(string $locale): array
     {

--- a/tests/CategoryTest.php
+++ b/tests/CategoryTest.php
@@ -68,6 +68,39 @@ final class CategoryTest extends TestCase
         );
     }
 
+    public function testGetMessages(): void
+    {
+        $categorySource = new CategorySource(
+            'test',
+            new class () implements MessageReaderInterface {
+                public function getMessage(
+                    string $id,
+                    string $category,
+                    string $locale,
+                    array $parameters = []
+                ): ?string {
+                    return null;
+                }
+
+                public function getMessages(string $category, string $locale): array
+                {
+                    return [
+                        'message1' => ['message' => 'message1'],
+                        'message2' => ['message' => 'message2'],
+                    ];
+                }
+            }
+        );
+
+        $this->assertEquals(
+            [
+                'message1' => ['message' => 'message1'],
+                'message2' => ['message' => 'message2'],
+            ],
+            $categorySource->getMessages('en'),
+        );
+    }
+
     private function createMessageReader(): MessageReaderInterface
     {
         return new class () implements MessageReaderInterface {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Due to `reader` has `getMessages` method it may be helpful to use it with CategorySource, for example, when you want to export all message to external service.

