### PR TITLE
In `SimpleMessageFormatter` add support of messages where used parameters with plural modifier that contain non-supported keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.2.1 under development
 
-- no changes in this release.
+- Enh #99: In `SimpleMessageFormatter` add support of messages where used parameters with plural modifier that contain 
+  non-supported keys (@vjik)
 
 ## 2.2.0 November 28, 2022
 

--- a/src/SimpleMessageFormatter.php
+++ b/src/SimpleMessageFormatter.php
@@ -77,17 +77,14 @@ class SimpleMessageFormatter implements MessageFormatterInterface
         $map = [];
         foreach ($pluralMatches[1] as $index => $match) {
             if (!in_array($match, self::PLURAL_KEYS, true)) {
-                $keysStr = self::formatList(self::PLURAL_KEYS);
-
-                throw new InvalidArgumentException("Invalid plural key - \"$match\". The valid keys are $keysStr.");
+                continue;
             }
 
             $map[$match] = $pluralMatches[3][$index];
         }
 
-        $diff = array_diff(self::PLURAL_KEYS, $pluralMatches[1]);
-        if ($diff !== []) {
-            throw new InvalidArgumentException('Missing plural keys: ' . self::formatList($diff) . '.');
+        if (!in_array(self::PLURAL_OTHER, $pluralMatches[1], true)) {
+            throw new InvalidArgumentException('Missing plural key "' . self::PLURAL_OTHER . '".');
         }
 
         return $value === 1 ? $map[self::PLURAL_ONE] : $map[self::PLURAL_OTHER];

--- a/tests/SimpleMessageFormatterTest.php
+++ b/tests/SimpleMessageFormatterTest.php
@@ -77,13 +77,13 @@ class SimpleMessageFormatterTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testFormatPluralWithWrongKey(): void
+    public function testFormatPluralWithNotSupportedKey(): void
     {
         $formatter = new SimpleMessageFormatter();
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid plural key - "many". The valid keys are "one", "other".');
-        $formatter->format('{min, plural, one{character} many{characters}}', ['min' => 1]);
+        $result = $formatter->format('{min, plural, one{character} many{characters} other{characters}}', ['min' => 2]);
+
+        $this->assertSame('characters', $result);
     }
 
     public function testFormatPluralWithNonInteger(): void
@@ -100,7 +100,7 @@ class SimpleMessageFormatterTest extends TestCase
         $formatter = new SimpleMessageFormatter();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Missing plural keys: "other".');
+        $this->expectExceptionMessage('Missing plural key "other".');
         $formatter->format('{min, plural, one{character}}', ['min' => 1]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -