### PR TITLE
Throw `InvalidArgumentException` when missed "one" plural key + Fix psalm

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -10,6 +10,8 @@ on:
       - 'phpunit.xml.dist'
 
   push:
+    branches:
+      - master
     paths-ignore:
       - 'docs/**'
       - 'README.md'
@@ -28,4 +30,12 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.0', '8.1']
+        ['8.1', '8.2', '8.3']
+  psalm80:
+    uses: yiisoft/actions/.github/workflows/psalm.yml@master
+    with:
+      psalm-config: psalm80.xml
+      os: >-
+        ['ubuntu-latest']
+      php: >-
+        ['8.0']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.1 under development
 
-- no changes in this release.
+- Enh #131: Throw `InvalidArgumentException` when missed "one" plural key (@vjik) 
 
 ## 3.0.0 February 17, 2023
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "rector/rector": "^1.0.0",
         "roave/infection-static-analysis-plugin": "^1.25",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.30|^5.4",
+        "vimeo/psalm": "^4.30|^5.21",
         "yiisoft/di": "^1.2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^4.2",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "rector/rector": "^1.0.0",
         "roave/infection-static-analysis-plugin": "^1.25",
         "spatie/phpunit-watcher": "^1.23",

--- a/psalm80.xml
+++ b/psalm80.xml
@@ -15,6 +15,5 @@
     </projectFiles>
     <issueHandlers>
         <MixedAssignment errorLevel="suppress" />
-        <RiskyTruthyFalsyComparison errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/src/SimpleMessageFormatter.php
+++ b/src/SimpleMessageFormatter.php
@@ -83,7 +83,11 @@ class SimpleMessageFormatter implements MessageFormatterInterface
             $map[$match] = $pluralMatches[3][$index];
         }
 
-        if (!in_array(self::PLURAL_OTHER, $pluralMatches[1], true)) {
+        if (!isset($map[self::PLURAL_ONE])) {
+            throw new InvalidArgumentException('Missing plural key "' . self::PLURAL_ONE . '".');
+        }
+
+        if (!isset($map[self::PLURAL_OTHER])) {
             throw new InvalidArgumentException('Missing plural key "' . self::PLURAL_OTHER . '".');
         }
 

--- a/tests/SimpleMessageFormatterTest.php
+++ b/tests/SimpleMessageFormatterTest.php
@@ -100,13 +100,22 @@ class SimpleMessageFormatterTest extends TestCase
         $formatter->format('{min, plural, one{character} other{characters}}', ['min' => 'str']);
     }
 
-    public function testFormatPluralWithMissingKey(): void
+    public function testFormatPluralWithMissingOtherKey(): void
     {
         $formatter = new SimpleMessageFormatter();
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Missing plural key "other".');
         $formatter->format('{min, plural, one{character}}', ['min' => 1]);
+    }
+
+    public function testFormatPluralWithMissingOneKey(): void
+    {
+        $formatter = new SimpleMessageFormatter();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing plural key "one".');
+        $formatter->format('{min, plural, other{characters}}', ['min' => 1]);
     }
 
     public function dataFormatPluralWithMissingKeys(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

