### PR TITLE
Fix incorrect locale usage when message ID is not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.1 under development
 
 - Enh #131: Throw `InvalidArgumentException` when missed "one" plural key (@vjik) 
-- Bug #132: Fix incorrect locale usage when message ID is not exist (@vjik)
+- Bug #132: Fix incorrect locale usage when category source is not exist and specified fallback locale (@vjik)
 
 ## 3.0.0 February 17, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.1 under development
 
 - Enh #131: Throw `InvalidArgumentException` when missed "one" plural key (@vjik) 
+- Bug #132: Fix incorrect locale usage when message ID is not exist (@vjik)
 
 ## 3.0.0 February 17, 2023
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -84,7 +84,7 @@ final class Translator implements TranslatorInterface
             return $this->defaultMessageFormatter->format((string) $id, $parameters, $locale);
         }
 
-        return $this->translateUsingCategorySources((string) $id, $parameters, $category, $locale, $locale);
+        return $this->translateUsingCategorySources((string) $id, $parameters, $category, $locale);
     }
 
     public function withDefaultCategory(string $category): static
@@ -109,11 +109,9 @@ final class Translator implements TranslatorInterface
         string $id,
         array $parameters,
         string $category,
-        string $locale,
-        string $defaultLocale,
+        string $locale
     ): string {
-        $endSourceCategory = end($this->categorySources[$category]);
-        $sourceCategory = $endSourceCategory;
+        $sourceCategory = end($this->categorySources[$category]);
         do {
             $message = $sourceCategory->getMessage($id, $locale, $parameters);
 
@@ -128,26 +126,20 @@ final class Translator implements TranslatorInterface
         $fallback = $localeObject->fallbackLocale();
 
         if ($fallback->asString() !== $localeObject->asString()) {
-            return $this->translateUsingCategorySources($id, $parameters, $category, $fallback->asString(), $locale);
+            return $this->translateUsingCategorySources($id, $parameters, $category, $fallback->asString());
         }
 
         if (!empty($this->fallbackLocale)) {
             $fallbackLocaleObject = (new Locale($this->fallbackLocale))->fallbackLocale();
             if ($fallbackLocaleObject->asString() !== $localeObject->asString()) {
-                return $this->translateUsingCategorySources(
-                    $id,
-                    $parameters,
-                    $category,
-                    $fallbackLocaleObject->asString(),
-                    $locale
-                );
+                return $this->translateUsingCategorySources($id, $parameters, $category, $fallbackLocaleObject->asString());
             }
         }
 
-        return $endSourceCategory->format(
+        return end($this->categorySources[$category])->format(
             $id,
             $parameters,
-            $defaultLocale,
+            $locale,
             $this->defaultMessageFormatter
         );
     }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -81,7 +81,7 @@ final class Translator implements TranslatorInterface
 
         if (empty($this->categorySources[$category])) {
             $this->dispatchMissingTranslationCategoryEvent($category);
-            return $this->defaultMessageFormatter->format((string) $id, $parameters, $locale);
+            return $this->defaultMessageFormatter->format((string) $id, $parameters, $this->fallbackLocale ?? $locale);
         }
 
         return $this->translateUsingCategorySources((string) $id, $parameters, $category, $locale);

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -136,12 +136,7 @@ final class Translator implements TranslatorInterface
             }
         }
 
-        return end($this->categorySources[$category])->format(
-            $id,
-            $parameters,
-            $locale,
-            $this->defaultMessageFormatter
-        );
+        return $this->defaultMessageFormatter->format($id, $parameters, $locale);
     }
 
     private function dispatchMissingTranslationCategoryEvent(string $category): void

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -598,7 +598,7 @@ final class TranslatorTest extends TestCase
     {
         return [
             'with formatter' => [
-                'formatted by category',
+                'formatted by category (ru)',
                 new CategorySource(
                     'withFormatter',
                     $this->createMessageReader(
@@ -614,13 +614,13 @@ final class TranslatorTest extends TestCase
                     new class () implements MessageFormatterInterface {
                         public function format(string $message, array $parameters, string $locale): string
                         {
-                            return 'formatted by category';
+                            return 'formatted by category (' . $locale . ')';
                         }
                     },
                 ),
             ],
             'without formatter' => [
-                'formatted by translator',
+                'formatted by translator (ru)',
                 new CategorySource(
                     'withoutFormatter',
                     $this->createMessageReader(
@@ -646,11 +646,12 @@ final class TranslatorTest extends TestCase
         CategorySource $categorySource
     ): void {
         $translator = new Translator(
-            locale: 'en',
+            locale: 'ru',
+            fallbackLocale: 'en',
             defaultMessageFormatter: new class () implements MessageFormatterInterface {
                 public function format(string $message, array $parameters, string $locale): string
                 {
-                    return 'formatted by translator';
+                    return 'formatted by translator (' . $locale . ')';
                 }
             },
         );
@@ -658,74 +659,7 @@ final class TranslatorTest extends TestCase
 
         $this->assertSame(
             $expectedMessage,
-            $translator->translate('hello', [], $categorySource->getName())
-        );
-    }
-
-    public function dataDefaultMessageFormatterWithoutId(): array
-    {
-        return [
-            'without category' => [null],
-            'category with formatter' => [
-                new CategorySource(
-                    'withFormatter',
-                    $this->createMessageReader(
-                        'withFormatter',
-                        [
-                            'withFormatter' => [
-                                'en' => [
-                                    'hello' => 'Hello, {name}!',
-                                ],
-                            ],
-                        ]
-                    ),
-                    new class () implements MessageFormatterInterface {
-                        public function format(string $message, array $parameters, string $locale): string
-                        {
-                            return 'formatted by category';
-                        }
-                    },
-                ),
-            ],
-            'category without formatter' => [
-                new CategorySource(
-                    'withoutFormatter',
-                    $this->createMessageReader(
-                        'withoutFormatter',
-                        [
-                            'withoutFormatter' => [
-                                'en' => [
-                                    'hello' => 'Hello, {name}!',
-                                ],
-                            ],
-                        ]
-                    ),
-                ),
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider dataDefaultMessageFormatterWithoutId
-     */
-    public function testDefaultMessageFormatterWithoutId(?CategorySource $categorySource): void
-    {
-        $translator = new Translator(
-            locale: 'en',
-            defaultMessageFormatter: new class () implements MessageFormatterInterface {
-                public function format(string $message, array $parameters, string $locale): string
-                {
-                    return 'formatted by translator';
-                }
-            },
-        );
-        if ($categorySource !== null) {
-            $translator->addCategorySources($categorySource);
-        }
-
-        $this->assertSame(
-            'formatted by translator',
-            $translator->translate('non-exist-id', [], 'test-category')
+            $translator->translate('test', [], $categorySource->getName())
         );
     }
 

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -658,7 +658,74 @@ final class TranslatorTest extends TestCase
 
         $this->assertSame(
             $expectedMessage,
-            $translator->translate('test', [], $categorySource->getName())
+            $translator->translate('hello', [], $categorySource->getName())
+        );
+    }
+
+    public function dataDefaultMessageFormatterWithoutId(): array
+    {
+        return [
+            'without category' => [null],
+            'category with formatter' => [
+                new CategorySource(
+                    'withFormatter',
+                    $this->createMessageReader(
+                        'withFormatter',
+                        [
+                            'withFormatter' => [
+                                'en' => [
+                                    'hello' => 'Hello, {name}!',
+                                ],
+                            ],
+                        ]
+                    ),
+                    new class () implements MessageFormatterInterface {
+                        public function format(string $message, array $parameters, string $locale): string
+                        {
+                            return 'formatted by category';
+                        }
+                    },
+                ),
+            ],
+            'category without formatter' => [
+                new CategorySource(
+                    'withoutFormatter',
+                    $this->createMessageReader(
+                        'withoutFormatter',
+                        [
+                            'withoutFormatter' => [
+                                'en' => [
+                                    'hello' => 'Hello, {name}!',
+                                ],
+                            ],
+                        ]
+                    ),
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataDefaultMessageFormatterWithoutId
+     */
+    public function testDefaultMessageFormatterWithoutId(?CategorySource $categorySource): void
+    {
+        $translator = new Translator(
+            locale: 'en',
+            defaultMessageFormatter: new class () implements MessageFormatterInterface {
+                public function format(string $message, array $parameters, string $locale): string
+                {
+                    return 'formatted by translator';
+                }
+            },
+        );
+        if ($categorySource !== null) {
+            $translator->addCategorySources($categorySource);
+        }
+
+        $this->assertSame(
+            'formatted by translator',
+            $translator->translate('non-exist-id', [], 'test-category')
         );
     }
 

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -662,6 +662,43 @@ final class TranslatorTest extends TestCase
         );
     }
 
+    public static function dataDefaultMessageFormatterWithoutCategory(): array
+    {
+        return [
+            'another-fallback-locale' => [
+                '(en)',
+                'en',
+            ],
+            'same-fallback-locale' => [
+                '(ru)',
+                'ru',
+            ],
+            'without-fallback-locale' => [
+                '(ru)',
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataDefaultMessageFormatterWithoutCategory
+     */
+    public function testDefaultMessageFormatterWithoutCategory(string $expected, ?string $fallbackLocale)
+    {
+        $translator = new Translator(
+            locale: 'ru',
+            fallbackLocale: $fallbackLocale,
+            defaultMessageFormatter: new class () implements MessageFormatterInterface {
+                public function format(string $message, array $parameters, string $locale): string
+                {
+                    return '(' . $locale . ')';
+                }
+            },
+        );
+
+        $this->assertSame($expected, $translator->translate('test'));
+    }
+
     public function testFluentInterface(): void
     {
         $translator = new Translator();

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -598,7 +598,7 @@ final class TranslatorTest extends TestCase
     {
         return [
             'with formatter' => [
-                'formatted by category (ru)',
+                'formatted by category',
                 new CategorySource(
                     'withFormatter',
                     $this->createMessageReader(
@@ -614,13 +614,13 @@ final class TranslatorTest extends TestCase
                     new class () implements MessageFormatterInterface {
                         public function format(string $message, array $parameters, string $locale): string
                         {
-                            return 'formatted by category (' . $locale . ')';
+                            return 'formatted by category';
                         }
                     },
                 ),
             ],
             'without formatter' => [
-                'formatted by translator (ru)',
+                'formatted by translator',
                 new CategorySource(
                     'withoutFormatter',
                     $this->createMessageReader(
@@ -646,12 +646,11 @@ final class TranslatorTest extends TestCase
         CategorySource $categorySource
     ): void {
         $translator = new Translator(
-            locale: 'ru',
-            fallbackLocale: 'en',
+            locale: 'en',
             defaultMessageFormatter: new class () implements MessageFormatterInterface {
                 public function format(string $message, array $parameters, string $locale): string
                 {
-                    return 'formatted by translator (' . $locale . ')';
+                    return 'formatted by translator';
                 }
             },
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
