### PR TITLE
Fix the nullable parameter declarations for compatibility with PHP 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #131: Throw `InvalidArgumentException` when missed "one" plural key (@vjik) 
 - Bug #132: Fix incorrect locale usage when category source is not exist and specified fallback locale (@vjik)
+- Bug #148: Fix the nullable parameter declarations for compatibility with PHP 8.4 (@martio)
 
 ## 3.0.0 February 17, 2023
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -72,8 +72,8 @@ final class Translator implements TranslatorInterface
     public function translate(
         string|Stringable $id,
         array $parameters = [],
-        string $category = null,
-        string $locale = null
+        ?string $category = null,
+        ?string $locale = null
     ): string {
         $locale ??= $this->locale;
 

--- a/src/TranslatorInterface.php
+++ b/src/TranslatorInterface.php
@@ -46,8 +46,8 @@ interface TranslatorInterface
     public function translate(
         string|Stringable $id,
         array $parameters = [],
-        string $category = null,
-        string $locale = null
+        ?string $category = null,
+        ?string $locale = null
     ): string;
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | :white_check_mark:/:heavy_multiplication_x:
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

I have prepared a small fix that resolves the following issue:

```
DEPRECATED  Yiisoft\Translator\TranslatorInterface::translate(): Implicitly marking parameter $locale as nullable is deprecated, the explicit nullable type must be used instead in vendor/yiisoft/translator/src/TranslatorInterface.php on line 46.
```

`Yiisoft\Translator\TranslatorInterface`

```php
   public function translate(
       string|Stringable $id,
       array $parameters = [],
       string $category = null,
       string $locale = null
   ): string;
```